### PR TITLE
Update to vtt-overview and foundry basics

### DIFF
--- a/site/foundry-basics/index.html
+++ b/site/foundry-basics/index.html
@@ -632,7 +632,7 @@ The Pencil icon is the Draw Shape function.</p>
 
 <h3 id="highlight-a-target">Highlight a Target<a class="headerlink" href="#highlight-a-target" title="Permanent link">⚑</a></h3>
 <hr />
-<p>Click on the <code>Target</code> icon on the left. Click on the token you ant to target. This will highlight it on the map for you.</p>
+<p>Click on the <code>Target</code> icon on the left. Click on the token you want to target. This will highlight it on the map for you. Alternatively, you can hover over the token you want to target and press "T" on your keyboard.</p>
 <div style='position:relative; padding-bottom:calc(56.25% + 44px)'><iframe src='https://gfycat.com/ifr/feistyprestigiousborderterrier?autoplay=0' frameborder='0' scrolling='no' width='100%' height='100%' style='position:absolute;top:0;left:0;' allowfullscreen></iframe></div>
 
 <h3 id="measure-distance">Measure Distance<a class="headerlink" href="#measure-distance" title="Permanent link">⚑</a></h3>

--- a/site/vtts-overview/index.html
+++ b/site/vtts-overview/index.html
@@ -536,8 +536,8 @@
 <tr>
 <th align="left">Feature</th>
 <th align="left">Free</th>
-<th align="left">Partner Hosted</th>
-<th align="left">Cloud Hosted</th>
+<th align="left">Plus</th>
+<th align="left">Pro</th>
 </tr>
 </thead>
 <tbody>
@@ -669,7 +669,7 @@
 <td align="left">Monthly Hosting</td>
 <td align="left"><span class="twemoji"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg></span></td>
 <td align="left">$4-12</td>
-<td align="left">$10-20</td>
+<td align="left">$0-20</td>
 </tr>
 <tr>
 <td align="left">Game Access</td>
@@ -693,7 +693,7 @@
 <td align="left"><strong>1st YEAR COST</strong></td>
 <td align="left"><strong>$50</strong></td>
 <td align="left"><strong>$98-194</strong></td>
-<td align="left"><strong>$170-290</strong></td>
+<td align="left"><strong>$50-290</strong></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Roll20 pricing columns were mislabeled.
Updated Pricing of Foundry Cloud Hosted. Several options exist to host for free (Oracle Always Free, AWS Free Tier), or for comparable pricing of Partner Hosted (Digital ocean $5 droplet, or any similar service). Realistic cost is $0-20 to partner host with the major downside being you are your own tech support.